### PR TITLE
Add DB role to servers for cap

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -3,5 +3,5 @@
 set :stage, :production
 set :rails_env, 'production'
 
-server 'allsearch-api-prod1', user: 'deploy', roles: ['app']
-server 'allsearch-api-prod2', user: 'deploy', roles: ['app']
+server 'allsearch-api-prod1', user: 'deploy', roles: [:app, :db]
+server 'allsearch-api-prod2', user: 'deploy', roles: [:app]

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -3,4 +3,4 @@
 set :stage, :staging
 set :rails_env, 'staging'
 
-server 'allsearch-api-staging1', user: 'deploy', roles: ['app']
+server 'allsearch-api-staging1', user: 'deploy', roles: [:app, :db]


### PR DESCRIPTION
From local deploy to staging:

```
 INFO [8c52f412] Running bundle exec rake db:migrate as deploy@allsearch-api-staging1
 DEBUG [8c52f412] Command: cd /opt/allsearch_rails_api/releases/20230920183935 && ( export RAILS_ENV="staging" ; bundle exec rake db:migrate )
```

Closes #88 